### PR TITLE
【Fixed】Issues/#1

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -15,10 +15,15 @@ class AssignsController < ApplicationController
   end
 
   def destroy
-    assign = Assign.find(params[:id])
-    destroy_message = assign_destroy(assign, assign.user)
+      assign = Assign.find(params[:id])
+      destroy_message = assign_destroy(assign, assign.user)
+      current_team = Team.find_by(id: assign.team_id)
 
-    redirect_to team_url(params[:team_id]), notice: destroy_message
+    if current_user.id == current_team.owner_id || current_user.id == assign.user_id
+      redirect_to team_url(params[:team_id]), notice: destroy_message
+    else
+      redirect_to team_url(params[:team_id]), notice: destroy_message
+    end
   end
 
   private

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -15,7 +15,12 @@ class TeamsController < ApplicationController
     @team = Team.new
   end
 
-  def edit; end
+  def edit
+    unless current_user.id == @team.owner_id
+      flash.now[:error] = I18n.t('views.messages.failed_to_save_team')
+      render :show
+    end
+  end
 
   def create
     @team = Team.new(team_params)
@@ -30,11 +35,16 @@ class TeamsController < ApplicationController
   end
 
   def update
-    if @team.update(team_params)
-      redirect_to @team, notice: I18n.t('views.messages.update_team')
+    if current_user.id == @team.owner_id
+      if @team.update(team_params)
+        redirect_to @team, notice: I18n.t('views.messages.update_team')
+      else
+        flash.now[:error] = I18n.t('views.messages.failed_to_save_team')
+        render :edit
+      end
     else
       flash.now[:error] = I18n.t('views.messages.failed_to_save_team')
-      render :edit
+      render :show
     end
   end
 

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -46,11 +46,6 @@
                           <%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %>
                         <% end %>
                       </td>
-                      <td>
-                        <% if current_user.id == @team.owner_id %>
-                          <%= link_to I18n.t('views.button.edit'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %>
-                        <% end %>
-                      </td>
                     </tr>
                   <% end %>
                 </tbody>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -41,7 +41,11 @@
                     <tr>
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
-                      <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <td>
+                        <% if current_user == @team.owner_id || current_user.id == assign.user_id %>
+                          <%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %>
+                        <% end %>
+                      </td>
                     </tr>
                   <% end %>
                 </tbody>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -42,8 +42,13 @@
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
                       <td>
-                        <% if current_user == @team.owner_id || current_user.id == assign.user_id %>
+                        <% if current_user.id == @team.owner_id || current_user.id == assign.user_id %>
                           <%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %>
+                        <% end %>
+                      </td>
+                      <td>
+                        <% if current_user.id == @team.owner_id %>
+                          <%= link_to I18n.t('views.button.edit'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %>
                         <% end %>
                       </td>
                     </tr>


### PR DESCRIPTION
#1

- Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないように変更

- TeamのeditはTeamのリーダー（オーナー）のみができるように変更